### PR TITLE
typo

### DIFF
--- a/docs/contrib/mod_auth_otp.html
+++ b/docs/contrib/mod_auth_otp.html
@@ -324,7 +324,7 @@ have been provisioned with the necessary shared key.  To prevent
 continue using the standard FTP response messages, use the following in
 your configuration for <code>mod_auth_otp</code>:
 <pre>
-  AuthOTPOption StandardResponse
+  AuthOTPOptions StandardResponse
 </pre>
 
 <p>


### PR DESCRIPTION
2019-04-20 19:07:34,034 test proftpd[1]: fatal: unknown configuration directive 'AuthOTPOption' on line 102 of '/usr/local/proftpd-1.3.6.1555780941mc/etc/proftpd.conf'
2019-04-20 19:07:34,036 test proftpd[1]: fatal: Did you mean: AuthOTPOptions